### PR TITLE
Allow all pats from risk_score and from patient_outcomes

### DIFF
--- a/backend/api/api/tests.py
+++ b/backend/api/api/tests.py
@@ -359,7 +359,7 @@ class RequestTransfusedUnitsTestCaseLoggedOut(TransactionTestCase):
         response = self.c.get(self.endpoint)
         self.assertEqual(response.status_code, 302)
 
-    def test_risk_score_unsupported_methods(self):
+    def test_request_transfused_unsupported_methods(self):
         response = self.c.post(self.endpoint)
         self.assertEqual(response.status_code, 302)
         
@@ -556,7 +556,7 @@ class RequestTransfusedUnitsTestCaseLoggedIn(TransactionTestCase):
         response = self.c.get(self.endpoint)
         self.assertEqual(response.status_code, 400)
 
-    def test_risk_score_unsupported_methods(self):
+    def test_request_transfused_unsupported_methods(self):
         response = self.c.post(self.endpoint)
         self.assertEqual(response.status_code, 405)
         

--- a/backend/api/api/tests.py
+++ b/backend/api/api/tests.py
@@ -937,7 +937,7 @@ class PatientOutcomesTestCaseLoggedIn(TransactionTestCase):
 
     def test_risk_score_no_params(self):
         response = self.c.get(self.endpoint)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
 
     def test_risk_score_valid_types(self):
         valid_options = [

--- a/backend/api/api/tests.py
+++ b/backend/api/api/tests.py
@@ -865,7 +865,7 @@ class PatientOutcomesTestCaseLoggedOut(TransactionTestCase):
     def setUp(self):
         self.c = Client()
 
-    def test_risk_score_unsupported_methods(self):
+    def test_patient_outcomes_unsupported_methods(self):
         response = self.c.post(self.endpoint)
         self.assertEqual(response.status_code, 302)
         
@@ -887,11 +887,11 @@ class PatientOutcomesTestCaseLoggedOut(TransactionTestCase):
         response = self.c.trace(self.endpoint)
         self.assertEqual(response.status_code, 302)
 
-    def test_risk_score_no_params(self):
+    def test_patient_outcomes_no_params(self):
         response = self.c.get(self.endpoint)
         self.assertEqual(response.status_code, 302)
 
-    def test_risk_score_valid_types(self):
+    def test_patient_outcomes_valid_types(self):
         valid_options = [
             {"patient_ids": "880078673"},
             {"patient_ids": "880078673,865124568"},
@@ -913,7 +913,7 @@ class PatientOutcomesTestCaseLoggedIn(TransactionTestCase):
         User.objects.create_user('test_user', 'myemail@test.com', 'test_password')
         self.c.login(username = 'test_user', password = 'test_password')
 
-    def test_risk_score_unsupported_methods(self):
+    def test_patient_outcomes_unsupported_methods(self):
         response = self.c.post(self.endpoint)
         self.assertEqual(response.status_code, 405)
         
@@ -935,11 +935,11 @@ class PatientOutcomesTestCaseLoggedIn(TransactionTestCase):
         response = self.c.trace(self.endpoint)
         self.assertEqual(response.status_code, 405)
 
-    def test_risk_score_no_params(self):
+    def test_patient_outcomes_no_params(self):
         response = self.c.get(self.endpoint)
         self.assertEqual(response.status_code, 200)
 
-    def test_risk_score_valid_types(self):
+    def test_patient_outcomes_valid_types(self):
         valid_options = [
             {"patient_ids": "880078673"},
             {"patient_ids": "880078673,865124568"},

--- a/backend/api/api/tests.py
+++ b/backend/api/api/tests.py
@@ -843,7 +843,7 @@ class RiskScoreTestCaseLoggedIn(TransactionTestCase):
 
     def test_risk_score_no_params(self):
         response = self.c.get(self.endpoint)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
 
     def test_risk_score_valid_types(self):
         valid_options = [

--- a/backend/api/api/views.py
+++ b/backend/api/api/views.py
@@ -358,12 +358,13 @@ def risk_score(request):
         # Parse the ids
         patient_ids = patient_ids.split(",") if patient_ids else []
 
-        if not patient_ids:
-            return HttpResponseBadRequest("patient_ids must be supplied")
-
-        # Generate the patient filters
-        pat_bind_names = [f":pat_id{str(i)}" for i in range(len(patient_ids))]
-        pat_filters_safe_sql = f"AND DI_PAT_ID IN ({','.join(pat_bind_names)}) " if patient_ids != [] else ""
+        if patient_ids:
+            # Generate the patient filters
+            pat_bind_names = [f":pat_id{str(i)}" for i in range(len(patient_ids))]
+            pat_filters_safe_sql = f"AND DI_PAT_ID IN ({','.join(pat_bind_names)}) " if patient_ids != [] else ""
+        else:
+            pat_bind_names = []
+            pat_filters_safe_sql = ""
 
         # Defined the sql command
         command = f"""
@@ -414,10 +415,14 @@ def patient_outcomes(request):
         if not patient_ids:
             return HttpResponseBadRequest("patient_ids must be supplied")
 
-        # Generate the patient filters
-        pat_bind_names = [f":pat_id{str(i)}" for i in range(len(patient_ids))]
-        pat_filters_safe_sql = f"AND DI_PAT_ID IN ({','.join(pat_bind_names)}) " if patient_ids != [] else ""
-
+       if patient_ids:
+            # Generate the patient filters
+            pat_bind_names = [f":pat_id{str(i)}" for i in range(len(patient_ids))]
+            pat_filters_safe_sql = f"AND DI_PAT_ID IN ({','.join(pat_bind_names)}) " if patient_ids != [] else ""
+        else:
+            pat_bind_names = []
+            pat_filters_safe_sql = ""
+        
         # Defined the sql command
         command = f"""
         SELECT

--- a/backend/api/api/views.py
+++ b/backend/api/api/views.py
@@ -412,10 +412,7 @@ def patient_outcomes(request):
         # Parse the ids
         patient_ids = patient_ids.split(",") if patient_ids else []
 
-        if not patient_ids:
-            return HttpResponseBadRequest("patient_ids must be supplied")
-
-       if patient_ids:
+        if patient_ids:
             # Generate the patient filters
             pat_bind_names = [f":pat_id{str(i)}" for i in range(len(patient_ids))]
             pat_filters_safe_sql = f"AND DI_PAT_ID IN ({','.join(pat_bind_names)}) " if patient_ids != [] else ""


### PR DESCRIPTION
Remove the check for patient ids allowing the request to return all the patients at once.

Related to #13 